### PR TITLE
Fix jitpack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+install:
+  - mvn wrapper:wrapper -Dmaven=3.9.9
+  - ./mvnw -B install -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>deploy</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>jar-no-fork</goal>
 						</goals>


### PR DESCRIPTION
Jitpack uses an old version of maven by default, which is incompatible with the newer plugin versions.