### PR TITLE
Large performance increase from spatial indexes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,13 +122,6 @@
 			<artifactId>vecmath</artifactId>
 			<version>1.5.2</version>
 		</dependency>
-
-		<!-- https://mvnrepository.com/artifact/gov.nist.math/jama -->
-		<dependency>
-			<groupId>gov.nist.math</groupId>
-			<artifactId>jama</artifactId>
-			<version>1.0.3</version>
-		</dependency>
 		<dependency>
 			<groupId>org.tinspin</groupId>
 			<artifactId>tinspin-indexes</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
 			<artifactId>jama</artifactId>
 			<version>1.0.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.tinspin</groupId>
+			<artifactId>tinspin-indexes</artifactId>
+			<version>2.1.3</version>
+		</dependency>
 
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.twak.campskeleton</groupId>
 	<artifactId>campskeleton</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
+	<version>0.0.2-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
 	<packaging>jar</packaging>
 
 	<properties>
-		<maven.compiler.target>1.8</maven.compiler.target>
-		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
 	</properties>
 
 	<build>

--- a/src/org/twak/camp/CoSitedCollision.java
+++ b/src/org/twak/camp/CoSitedCollision.java
@@ -2,8 +2,10 @@
 package org.twak.camp;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -27,7 +29,7 @@ import org.twak.utils.geom.LinearForm3D;
  */
 public class CoSitedCollision
 {
-    public Set<EdgeCollision> edges = new LinkedHashSet();
+    public Collection<EdgeCollision> edges = new ArrayList<>(10);
     public Point3d loc;
 
     public boolean debugHoriz = false;
@@ -45,7 +47,7 @@ public class CoSitedCollision
 
     public void add(EdgeCollision ec)
     {
-        edges.add( ec );
+    	edges.add(ec);
     }
 
     /**
@@ -54,10 +56,10 @@ public class CoSitedCollision
      */
     public boolean findChains ( Skeleton skel )
     {
-        chains = new ArrayList();
+        chains = new ArrayList<>();
         
         // remove duplicate edges
-        Set<Edge> allEdges = new LinkedHashSet();
+        Set<Edge> allEdges = new HashSet<>();
         for (EdgeCollision ec : edges)
         {
             allEdges.add( ec.a );
@@ -124,7 +126,7 @@ public class CoSitedCollision
     }
 
     /**
-     * If another collision has been evaluated at teh same height, this method
+     * If another collision has been evaluated at the same height, this method
      * checks for any changes in the Corners involved in a skeleton. This is a problem
      * when several collisions at the same height occur against one smash edge.
      *

--- a/src/org/twak/camp/CollisionQ.java
+++ b/src/org/twak/camp/CollisionQ.java
@@ -12,9 +12,12 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import javax.vecmath.Point3d;
 import javax.vecmath.Tuple3d;
+import javax.vecmath.Vector3d;
 
 import org.twak.camp.debug.DebugDevice;
 import org.twak.utils.geom.LinearForm3D;
+
+import net.jafama.FastMath;
 
 /**
  *
@@ -198,9 +201,20 @@ public class CollisionQ
         }
     }
     
-    public static boolean isParallel (Edge a, Edge b) {
-    	return a.uphill.angle( b.uphill ) < 0.0001 && a.direction().angle( b.direction() ) < 0.0001;
-    }
+	static boolean isParallel(Edge a, Edge b) {
+		return angleBetween(a.uphill, b.uphill) < 0.0001 && angleBetween(a.direction(), b.direction()) < 0.0001;
+	}
+
+	private static double angleBetween(Vector3d v1, Vector3d v2) {
+		double vDot = v1.dot(v2);
+		double lenSq1 = v1.lengthSquared();
+		double lenSq2 = v2.lengthSquared();
+
+		// Normalize and clamp vDot
+		vDot = Math.max(-1.0, Math.min(1.0, vDot / Math.sqrt(lenSq1 * lenSq2)));
+
+		return FastMath.acos(vDot);
+	}
 
     private void cornerEdgeCollision( Corner corner, Edge edge )
     {

--- a/src/org/twak/camp/CollisionQ.java
+++ b/src/org/twak/camp/CollisionQ.java
@@ -6,6 +6,7 @@
 package org.twak.camp;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.PriorityQueue;
@@ -22,272 +23,278 @@ import org.twak.utils.geom.LinearForm3D;
  * @author twak
  */
 public class CollisionQ {
-    // Using PriorityQueue with an initial capacity based on liveCorners can help reduce re–allocations.
-	   private PriorityQueue<EdgeCollision> faceEvents;
-	    private PriorityQueue<HeightEvent> miscEvents;
-	    Skeleton skel;
-	    private Set<EdgeCollision> seen = new HashSet<>();
 
-	    // The spatial index for live edges:
-	    private EdgeSpatialIndex edgeIndex;
-	    
-	    final double gridCell;
+	private PriorityQueue<EdgeCollision> faceEvents;
+	private PriorityQueue<HeightEvent> miscEvents;
+	Skeleton skel;
+	private Set<EdgeCollision> seen = new HashSet<>();
 
-	    public CollisionQ(Skeleton skel) {
-	    	this(skel, 1000);
-	    }
-	    
-	    public CollisionQ(Skeleton skel, double cellSize) {
-	    	gridCell = cellSize;
-	        this.skel = skel;
-	        int initSize = Math.max(3, skel.liveCorners.size());
-	        faceEvents = new PriorityQueue<>(initSize, HeightEvent.heightComparator);
-	        miscEvents = new PriorityQueue<>(initSize, HeightEvent.heightComparator);
-	        // Choose a reasonable cell size based on your model’s scale.
-	        edgeIndex = new EdgeSpatialIndex(cellSize/2);
-	        
-	        // Insert all live edges into the index once.
-	        for (Edge e : skel.liveEdges) {
-	            edgeIndex.insert(e);
-	        }
-	    }
-    
-    /**
-     * Returns the next event, giving priority to (virtual) simultaneous collisions.
-     */
-    private HeightEvent nextEvent() {
-        EdgeCollision ec;
-        while (true) {
-            ec = faceEvents.poll();
-            if (ec == null) break;
-            // Only process events not previously “seen” and at a height above (or just above) current
-            if (!skel.seen.contains(ec) && ec.loc.z >= skel.height - 0.001)
-                break;
-        }
-        
-        HeightEvent he = miscEvents.peek();
-        if (ec == null)
-            return miscEvents.poll();
-        if (he == null) {
-            skel.seen.add(ec);
-            return ec;
-        }
-        if (he.getHeight() <= ec.getHeight()) {
-            faceEvents.add(ec);
-            return miscEvents.poll();
-        } else {
-            skel.seen.add(ec);
-            return ec;
-        }
-    }
-    
-    HeightCollision currentCoHeighted = null;
-    
-    public HeightEvent poll() {
-        currentCoHeighted = null;
-        HeightEvent next = nextEvent();
-        if (next instanceof EdgeCollision) {
-            List<EdgeCollision> coHeighted = new ArrayList<>();
-            EdgeCollision ec = (EdgeCollision) next;
-            coHeighted.add(ec);
-            double height = ec.getHeight();
-            
-            // Gather all face events whose height is within a narrow tolerance.
-            while (true) {
-                EdgeCollision higher = faceEvents.peek();
-                if (higher == null)
-                    break;
-                if (Math.abs(higher.getHeight() - height) < 0.00001) {
-                    faceEvents.poll();
-                    if (skel.seen.contains(higher))
-                        continue;
-                    height = higher.getHeight();
-                    skel.seen.add(higher);
-                    coHeighted.add(higher);
-                } else break;
-            }
-            currentCoHeighted = new HeightCollision(coHeighted);
-            return currentCoHeighted;
-        } else {
-            return next;
-        }
-    }
-    
-    public void add(HeightEvent he) {
-        if (he instanceof EdgeCollision)
-            faceEvents.add((EdgeCollision) he);
-        else
-            miscEvents.add(he);
-    }
-    
-    /**
-     * Add collisions for a new corner.
-     * The flag "useCache" allows you (when sure of topology) to skip checking events that were already set.
-     */
-    public void addCorner(Corner toAdd, HeightCollision postProcess) {
-        addCorner(toAdd, postProcess, false);
-    }
-    
-    public void addCorner(Corner toAdd, HeightCollision postProcess, boolean useCache) {
-        if (!skel.preserveParallel && toAdd.prevL.sameDirectedLine(toAdd.nextL)) {
-            removeCorner(toAdd);
-            return;
-        }
-        // Loop–of–two dissolve rule
-        if (toAdd.prevL == toAdd.nextC.nextL) {
-            skel.output.addOutputSideTo(toAdd, toAdd.nextC, toAdd.prevL, toAdd.nextL);
-            toAdd.nextL.currentCorners.remove(toAdd);
-            toAdd.nextL.currentCorners.remove(toAdd.nextC);
-            toAdd.prevL.currentCorners.remove(toAdd);
-            toAdd.prevL.currentCorners.remove(toAdd.nextC);
-            if (toAdd.nextL.currentCorners.isEmpty())
-                skel.liveEdges.remove(toAdd.nextL);
-            if (toAdd.prevL.currentCorners.isEmpty())
-                skel.liveEdges.remove(toAdd.prevL);
-            skel.liveCorners.remove(toAdd);
-            skel.liveCorners.remove(toAdd.nextC);
-            return;
-        }
-        
-        if (!skel.preserveParallel && toAdd.prevL.isCollisionNearHoriz(toAdd.nextL)) {
-            if (toAdd.nextL.direction().angle(toAdd.prevL.direction()) < 0.01)
-                postProcess.newHoriz(toAdd);
-            return;
-        }
+	// The spatial index for live edges:
+	private EdgeSpatialIndex edgeIndex;
 
-        // Instead of iterating over all liveEdges, query only those in the relevant search region.
-        // Determine a search box based on the corner’s approximate location and spread.
-        double searchRadius = gridCell; // This value may need tuning.
-        double minX = toAdd.x - searchRadius, minY = toAdd.y - searchRadius;
-        double maxX = toAdd.x + searchRadius, maxY = toAdd.y + searchRadius;
+	final int edgeNeighbors;
 
-        Set<Edge> candidateEdges = edgeIndex.search(minX, minY, maxX, maxY);
-        for (Edge e : candidateEdges) {
-            EdgeCollision ex = new EdgeCollision(null, toAdd.prevL, toAdd.nextL, e);
-            if (!useCache || !seen.contains(ex)) {
-                seen.add(ex);
-                cornerEdgeCollision(toAdd, e);
-            }
-        }
-    }
-    
-    private static final double COS_THRESHOLD = Math.cos(0.0001);
+	public CollisionQ(Skeleton skel) {
+		this(skel, Integer.MAX_VALUE);
+	}
 
-    public static boolean isParallel(Edge a, Edge b) {
-        return isAligned(a.uphill, b.uphill) && isAligned(a.direction(), b.direction());
-    }
+	public CollisionQ(Skeleton skel, int edgeNeighbors) {
+		this.skel = skel;
+		this.edgeNeighbors = edgeNeighbors;
+		int initSize = Math.max(3, skel.liveCorners.size());
+		faceEvents = new PriorityQueue<>(initSize, HeightEvent.heightComparator);
+		miscEvents = new PriorityQueue<>(initSize, HeightEvent.heightComparator);
+		if (edgeNeighbors != Integer.MAX_VALUE) {
+			edgeIndex = new EdgeSpatialIndex(skel.liveEdges);			
+		}
+	}
 
-    private static boolean isAligned(Vector3d v1, Vector3d v2) {
-    	
-        // Avoid division by zero
-        double lenSq1 = v1.lengthSquared();
-        double lenSq2 = v2.lengthSquared();
-        if (lenSq1 == 0.0 || lenSq2 == 0.0) {
-            return false;
-        }
+	/**
+	 * Returns the next event, giving priority to (virtual) simultaneous collisions.
+	 */
+	private HeightEvent nextEvent() {
+		EdgeCollision ec;
+		while (true) {
+			ec = faceEvents.poll();
+			if (ec == null)
+				break;
+			// Only process events not previously “seen” and at a height above (or just
+			// above) current
+			if (!skel.seen.contains(ec) && ec.loc.z >= skel.height - 0.001)
+				break;
+		}
 
-        // Compare squared quantities to avoid square root
-        double dotProduct = v1.dot(v2);
-        double squaredDot = dotProduct * dotProduct;
-        double threshold = COS_THRESHOLD * COS_THRESHOLD * lenSq1 * lenSq2;
+		HeightEvent he = miscEvents.peek();
+		if (ec == null)
+			return miscEvents.poll();
+		if (he == null) {
+			skel.seen.add(ec);
+			return ec;
+		}
+		if (he.getHeight() <= ec.getHeight()) {
+			faceEvents.add(ec);
+			return miscEvents.poll();
+		} else {
+			skel.seen.add(ec);
+			return ec;
+		}
+	}
 
-        return squaredDot >= threshold;
-    }
-    
-    public static boolean isParallel2(Edge a, Edge b) {
-        return angleBetween(a.uphill, b.uphill) < 0.0001 &&
-               angleBetween(a.direction(), b.direction()) < 0.0001;
-    }
-    
-    private static double angleBetween(Vector3d v1, Vector3d v2) {
-        double vDot = v1.dot(v2);
-        double lenSq1 = v1.lengthSquared();
-        double lenSq2 = v2.lengthSquared();
-        vDot = Math.max(-1.0, Math.min(1.0, vDot / Math.sqrt(lenSq1 * lenSq2)));
-        return Math.acos(vDot);
-    }
-    
-    private void cornerEdgeCollision(Corner corner, Edge edge) {
-        if (skel.preserveParallel) {
-            if (isParallel(edge, corner.prevL) && isParallel(edge, corner.nextL))
-                return;
-            if (corner.nextL == edge || corner.prevL == edge)
-                return;
-        } else {
-            if (isParallel(edge, corner.prevL) || isParallel(edge, corner.nextL))
-                return;
-        }
-        Tuple3d res = null;
-        try {
-            if (corner.prevL.linearForm.hasNaN() || corner.nextL.linearForm.hasNaN() || edge.linearForm.hasNaN())
-                throw new Error();
-            if (skel.preserveParallel && isParallel(corner.nextL, corner.prevL)) {
-                LinearForm3D fake = new LinearForm3D(corner.nextL.direction(), corner);
-                res = edge.linearForm.collide(fake, corner.prevL.linearForm);
-            } else {
-                res = edge.linearForm.collide(corner.prevL.linearForm, corner.nextL.linearForm);
-            }
-        } catch (Throwable f) {
-            // [Fallback collision computations...]
-        }
-        if (res != null) {
-            if (res.z < corner.z || res.z < edge.start.z)
-                return;
-            EdgeCollision ec = new EdgeCollision(new Point3d(res), corner.prevL, corner.nextL, edge);
-            if (!skel.seen.contains(ec))
-                faceEvents.offer(ec);
-        }
-    }
-    
-    boolean holdRemoves = false;
-    List<Corner> removes = new ArrayList<>();
-    
-    public void holdRemoves() {
-        removes.clear();
-        holdRemoves = true;
-    }
-    
-    public void resumeRemoves() {
-        holdRemoves = false;
-        for (Corner c : removes)
-            if (skel.liveCorners.contains(c))
-                removeCorner(c);
-        removes.clear();
-    }
-    
-    private void removeCorner(Corner toAdd) {
-        if (holdRemoves) {
-            removes.add(toAdd);
-            return;
-        }
-        DebugDevice.dump("about to delete " + toAdd, skel);
-        toAdd.prevC.nextC = toAdd.nextC;
-        toAdd.nextC.prevC = toAdd.prevC;
-        toAdd.nextC.prevL = toAdd.prevL;
-        skel.liveCorners.remove(toAdd);
-        for (Corner lc : skel.liveCorners) {
-            if (lc.nextL == toAdd.nextL)
-                lc.nextL = toAdd.prevL;
-            if (lc.prevL == toAdd.nextL)
-                lc.prevL = toAdd.prevL;
-        }
-        if (toAdd.prevL != toAdd.nextL) {
-            skel.liveEdges.remove(toAdd.nextL);
-            for (Corner c : toAdd.nextL.currentCorners)
-                toAdd.prevL.currentCorners.add(c);
-            skel.output.merge(toAdd.prevC, toAdd);
-            skel.refindAllFaceEventsLater();
-        }
-        toAdd.prevL.currentCorners.remove(toAdd);
-    }
-    
-    public void dump() {
-        int i = 0;
-        for (EdgeCollision ec : faceEvents)
-            System.out.println(String.format("%d : %s ", i++, ec));
-    }
-    
-    public void clearFaceEvents() { faceEvents.clear(); }
-    public void clearOtherEvents() { miscEvents.clear(); }
+	HeightCollision currentCoHeighted = null;
+
+	public HeightEvent poll() {
+		currentCoHeighted = null;
+		HeightEvent next = nextEvent();
+		if (next instanceof EdgeCollision) {
+			List<EdgeCollision> coHeighted = new ArrayList<>();
+			EdgeCollision ec = (EdgeCollision) next;
+			coHeighted.add(ec);
+			double height = ec.getHeight();
+
+			// Gather all face events whose height is within a narrow tolerance.
+			while (true) {
+				EdgeCollision higher = faceEvents.peek();
+				if (higher == null)
+					break;
+				if (Math.abs(higher.getHeight() - height) < 0.00001) {
+					faceEvents.poll();
+					if (skel.seen.contains(higher))
+						continue;
+					height = higher.getHeight();
+					skel.seen.add(higher);
+					coHeighted.add(higher);
+				} else
+					break;
+			}
+			currentCoHeighted = new HeightCollision(coHeighted);
+			return currentCoHeighted;
+		} else {
+			return next;
+		}
+	}
+
+	public void add(HeightEvent he) {
+		if (he instanceof EdgeCollision)
+			faceEvents.add((EdgeCollision) he);
+		else
+			miscEvents.add(he);
+	}
+
+	/**
+	 * Add collisions for a new corner. The flag "useCache" allows you (when sure of
+	 * topology) to skip checking events that were already set.
+	 */
+	public void addCorner(Corner toAdd, HeightCollision postProcess) {
+		addCorner(toAdd, postProcess, false);
+	}
+
+	public void addCorner(Corner toAdd, HeightCollision postProcess, boolean useCache) {
+		if (!skel.preserveParallel && toAdd.prevL.sameDirectedLine(toAdd.nextL)) {
+			removeCorner(toAdd);
+			return;
+		}
+		// Loop–of–two dissolve rule
+		if (toAdd.prevL == toAdd.nextC.nextL) {
+			skel.output.addOutputSideTo(toAdd, toAdd.nextC, toAdd.prevL, toAdd.nextL);
+			toAdd.nextL.currentCorners.remove(toAdd);
+			toAdd.nextL.currentCorners.remove(toAdd.nextC);
+			toAdd.prevL.currentCorners.remove(toAdd);
+			toAdd.prevL.currentCorners.remove(toAdd.nextC);
+			if (toAdd.nextL.currentCorners.isEmpty())
+				skel.liveEdges.remove(toAdd.nextL);
+			if (toAdd.prevL.currentCorners.isEmpty())
+				skel.liveEdges.remove(toAdd.prevL);
+			skel.liveCorners.remove(toAdd);
+			skel.liveCorners.remove(toAdd.nextC);
+			return;
+		}
+
+		if (!skel.preserveParallel && toAdd.prevL.isCollisionNearHoriz(toAdd.nextL)) {
+			if (angleBetween(toAdd.nextL.direction(), toAdd.prevL.direction()) < 0.01) {
+				postProcess.newHoriz(toAdd);
+			}
+			return;
+		}
+		
+
+		Collection<Edge> candidateEdges;
+		if (edgeIndex == null) {
+			candidateEdges = skel.liveEdges;
+		}
+		else {
+			candidateEdges = edgeIndex.search(toAdd.x, toAdd.y, edgeNeighbors);			
+		}
+
+		for (Edge e : candidateEdges) {
+			EdgeCollision ex = new EdgeCollision(null, toAdd.prevL, toAdd.nextL, e);
+			if (!useCache || !seen.contains(ex)) {
+				seen.add(ex);
+				cornerEdgeCollision(toAdd, e);
+			}
+		}
+	}
+
+	private static final double COS_THRESHOLD = Math.cos(0.0001);
+
+	static boolean isParallel(Edge a, Edge b) {
+		return isAligned(a.uphill, b.uphill) && isAligned(a.direction(), b.direction());
+	}
+
+	private static boolean isAligned(Vector3d v1, Vector3d v2) {
+
+		// Avoid division by zero
+		double lenSq1 = v1.lengthSquared();
+		double lenSq2 = v2.lengthSquared();
+		if (lenSq1 == 0.0 || lenSq2 == 0.0) {
+			return false;
+		}
+
+		// Compare squared quantities to avoid square root
+		double dotProduct = v1.dot(v2);
+		double squaredDot = dotProduct * dotProduct;
+		double threshold = COS_THRESHOLD * COS_THRESHOLD * lenSq1 * lenSq2;
+
+		return squaredDot >= threshold;
+	}
+
+	static boolean isParallel2(Edge a, Edge b) { // old slower method
+		return angleBetween(a.uphill, b.uphill) < 0.0001 && angleBetween(a.direction(), b.direction()) < 0.0001;
+	}
+
+	private static double angleBetween(Vector3d v1, Vector3d v2) {
+		double vDot = v1.dot(v2);
+		double lenSq1 = v1.lengthSquared();
+		double lenSq2 = v2.lengthSquared();
+		vDot = Math.max(-1.0, Math.min(1.0, vDot / Math.sqrt(lenSq1 * lenSq2)));
+		return Math.acos(vDot);
+	}
+
+	private void cornerEdgeCollision(Corner corner, Edge edge) {
+		if (skel.preserveParallel) {
+			if (isParallel(edge, corner.prevL) && isParallel(edge, corner.nextL))
+				return;
+			if (corner.nextL == edge || corner.prevL == edge)
+				return;
+		} else {
+			if (isParallel(edge, corner.prevL) || isParallel(edge, corner.nextL))
+				return;
+		}
+		Tuple3d res = null;
+		try {
+			if (corner.prevL.linearForm.hasNaN() || corner.nextL.linearForm.hasNaN() || edge.linearForm.hasNaN())
+				throw new Error();
+			if (skel.preserveParallel && isParallel(corner.nextL, corner.prevL)) {
+				LinearForm3D fake = new LinearForm3D(corner.nextL.direction(), corner);
+				res = edge.linearForm.collide(fake, corner.prevL.linearForm);
+			} else {
+				res = edge.linearForm.collide(corner.prevL.linearForm, corner.nextL.linearForm);
+			}
+		} catch (Throwable f) {
+			// [Fallback collision computations...]
+		}
+		if (res != null) {
+			if (res.z < corner.z || res.z < edge.start.z)
+				return;
+			EdgeCollision ec = new EdgeCollision(new Point3d(res), corner.prevL, corner.nextL, edge);
+			
+			if (!skel.seen.contains(ec))
+				faceEvents.offer(ec);
+		}
+	}
+
+	boolean holdRemoves = false;
+	List<Corner> removes = new ArrayList<>();
+
+	public void holdRemoves() {
+		removes.clear();
+		holdRemoves = true;
+	}
+
+	public void resumeRemoves() {
+		holdRemoves = false;
+		for (Corner c : removes)
+			if (skel.liveCorners.contains(c))
+				removeCorner(c);
+		removes.clear();
+	}
+
+	private void removeCorner(Corner toAdd) {
+		if (holdRemoves) {
+			removes.add(toAdd);
+			return;
+		}
+		DebugDevice.dump("about to delete " + toAdd, skel);
+		toAdd.prevC.nextC = toAdd.nextC;
+		toAdd.nextC.prevC = toAdd.prevC;
+		toAdd.nextC.prevL = toAdd.prevL;
+		skel.liveCorners.remove(toAdd);
+		for (Corner lc : skel.liveCorners) {
+			if (lc.nextL == toAdd.nextL)
+				lc.nextL = toAdd.prevL;
+			if (lc.prevL == toAdd.nextL)
+				lc.prevL = toAdd.prevL;
+		}
+		if (toAdd.prevL != toAdd.nextL) {
+			skel.liveEdges.remove(toAdd.nextL);
+			for (Corner c : toAdd.nextL.currentCorners)
+				toAdd.prevL.currentCorners.add(c);
+			skel.output.merge(toAdd.prevC, toAdd);
+			skel.refindAllFaceEventsLater();
+		}
+		toAdd.prevL.currentCorners.remove(toAdd);
+	}
+
+	public void dump() {
+		int i = 0;
+		for (EdgeCollision ec : faceEvents)
+			System.out.println(String.format("%d : %s ", i++, ec));
+	}
+
+	public void clearFaceEvents() {
+		faceEvents.clear();
+	}
+
+	public void clearOtherEvents() {
+		miscEvents.clear();
+	}
 }
-

--- a/src/org/twak/camp/CollisionQ.java
+++ b/src/org/twak/camp/CollisionQ.java
@@ -150,7 +150,7 @@ public class CollisionQ {
 		}
 
 		if (!skel.preserveParallel && toAdd.prevL.isCollisionNearHoriz(toAdd.nextL)) {
-			if (isParallel(toAdd.nextL, toAdd.prevL)) {
+			if (toAdd.nextL.isParallel(toAdd.prevL)) {
 				postProcess.newHoriz(toAdd);
 			}
 			return;
@@ -174,43 +174,21 @@ public class CollisionQ {
 		}
 	}
 
-	private static final double COS_THRESHOLD = Math.cos(0.0001);
-	static boolean isParallel(Edge a, Edge b) {
-		return isAligned(a.uphill, b.uphill) && isAligned(a.direction(), b.direction());
-	}
-
-	private static boolean isAligned(Vector3d v1, Vector3d v2) {
-
-		// Avoid division by zero
-		double lenSq1 = v1.lengthSquared();
-		double lenSq2 = v2.lengthSquared();
-		if (lenSq1 == 0.0 || lenSq2 == 0.0) {
-			return false;
-		}
-
-		// Compare squared quantities to avoid square root
-		double dotProduct = v1.dot(v2);
-		double squaredDot = dotProduct * dotProduct;
-		double threshold = COS_THRESHOLD * COS_THRESHOLD * lenSq1 * lenSq2;
-
-		return squaredDot >= threshold;
-	}
-
 	private void cornerEdgeCollision(Corner corner, Edge edge) {
 		if (skel.preserveParallel) {
-			if (isParallel(edge, corner.prevL) && isParallel(edge, corner.nextL))
-				return;
+			if (edge.isParallel(corner.prevL) && edge.isParallel(corner.nextL))
+			    return;
 			if (corner.nextL == edge || corner.prevL == edge)
-				return;
-		} else {
-			if (isParallel(edge, corner.prevL) || isParallel(edge, corner.nextL))
-				return;
-		}
+			    return;
+			} else {
+			    if (edge.isParallel(corner.prevL) || edge.isParallel(corner.nextL))
+			        return;
+			}
 		Tuple3d res = null;
 		try {
 			if (corner.prevL.linearForm.hasNaN() || corner.nextL.linearForm.hasNaN() || edge.linearForm.hasNaN())
 				throw new Error();
-			if (skel.preserveParallel && isParallel(corner.nextL, corner.prevL)) {
+			if (skel.preserveParallel && corner.nextL.isParallel(corner.prevL)) {
 				LinearForm3D fake = new LinearForm3D(corner.nextL.direction(), corner);
 				res = edge.linearForm.collide(fake, corner.prevL.linearForm);
 			} else {

--- a/src/org/twak/camp/CollisionQ.java
+++ b/src/org/twak/camp/CollisionQ.java
@@ -150,7 +150,7 @@ public class CollisionQ {
 		}
 
 		if (!skel.preserveParallel && toAdd.prevL.isCollisionNearHoriz(toAdd.nextL)) {
-			if (angleBetween(toAdd.nextL.direction(), toAdd.prevL.direction()) < 0.01) {
+			if (isParallel(toAdd.nextL, toAdd.prevL)) {
 				postProcess.newHoriz(toAdd);
 			}
 			return;
@@ -175,7 +175,6 @@ public class CollisionQ {
 	}
 
 	private static final double COS_THRESHOLD = Math.cos(0.0001);
-
 	static boolean isParallel(Edge a, Edge b) {
 		return isAligned(a.uphill, b.uphill) && isAligned(a.direction(), b.direction());
 	}
@@ -195,18 +194,6 @@ public class CollisionQ {
 		double threshold = COS_THRESHOLD * COS_THRESHOLD * lenSq1 * lenSq2;
 
 		return squaredDot >= threshold;
-	}
-
-	static boolean isParallel2(Edge a, Edge b) { // old slower method
-		return angleBetween(a.uphill, b.uphill) < 0.0001 && angleBetween(a.direction(), b.direction()) < 0.0001;
-	}
-
-	private static double angleBetween(Vector3d v1, Vector3d v2) {
-		double vDot = v1.dot(v2);
-		double lenSq1 = v1.lengthSquared();
-		double lenSq2 = v2.lengthSquared();
-		vDot = Math.max(-1.0, Math.min(1.0, vDot / Math.sqrt(lenSq1 * lenSq2)));
-		return Math.acos(vDot);
 	}
 
 	private void cornerEdgeCollision(Corner corner, Edge edge) {

--- a/src/org/twak/camp/Edge.java
+++ b/src/org/twak/camp/Edge.java
@@ -1,11 +1,11 @@
 
 package org.twak.camp;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Vector;
 import javax.vecmath.Point2d;
 import javax.vecmath.Point3d;
 import javax.vecmath.Tuple3d;
@@ -42,12 +42,12 @@ public class Edge
     public LinearForm3D linearForm;
     
     // corners that currently reference this edge in prevL or nextL
-    public Set<Corner> currentCorners = new LinkedHashSet();
+    public List<Corner> currentCorners = new ArrayList<>();
 
     public Machine machine;
 
     // features that this edge has been tagged with
-    public Set<Tag> profileFeatures = new LinkedHashSet();
+    public Set<Tag> profileFeatures = new LinkedHashSet<Tag>();
 
 
     public Edge (Corner start, Corner end, double angle)
@@ -76,21 +76,21 @@ public class Edge
     /**
      * The perpendicular unit vector pointing up the slope of the side
      */
-    private void calculateUphill()
-    {
-        Vector3d vec = direction();
+    private void calculateUphill() {
+        // Compute the horizontal direction components directly
+        double dx = end.x - start.x;
+        double dy = end.y - start.y;
+        // Compute the inverse length (normalization factor)
+        double normInv = 1.0 / Math.sqrt(dx * dx + dy * dy);
         
-        // perpendicular in x,y plane
-        vec = new Vector3d ( -vec.y, vec.x, 0 );
-        vec.normalize();
-
-        // horizontal component
-        vec.scale( Math.sin(getAngle()) );
-
-        // vertical component
-        vec.add( new Vector3d (0,0,Math.cos( getAngle()) ) );
+        double sinA = Math.sin(angle);
+        double cosA = Math.cos(angle);
         
-        uphill = vec;
+        // The perpendicular (in x,y) of (dx, dy) normalized is (-dy/length, dx/length).
+        // Multiply by sin(angle) and add vertical component cos(angle)
+        uphill = new Vector3d(-dy * sinA * normInv,
+                              dx * sinA * normInv,
+                              cosA);
     }
     
     public double[] getBBox() {

--- a/src/org/twak/camp/Edge.java
+++ b/src/org/twak/camp/Edge.java
@@ -93,6 +93,14 @@ public class Edge
         uphill = vec;
     }
     
+    public double[] getBBox() {
+        double minX = Math.min(start.x, end.x);
+        double minY = Math.min(start.y, end.y);
+        double maxX = Math.max(start.x, end.x);
+        double maxY = Math.max(start.y, end.y);
+        return new double[]{minX, minY, maxX, maxY};
+    }
+    
     /**
      * finds the Ax + By + Cz = D form of the edge
      * Called when the the weight of the edge changes
@@ -122,12 +130,10 @@ public class Edge
     	return start.distance( end );
     }
     
-    public Vector3d direction()
-    {
-        Vector3d vec = new Vector3d ( this.end.x, this.end.y, 0 );
-        vec.sub( new Vector3d ( this.start.x, this.start.y, 0 ));
-        return vec;
+    public Vector3d direction() {
+        return new Vector3d(end.x - start.x, end.y - start.y, 0);
     }
+
 
     public Line projectDown()
     {

--- a/src/org/twak/camp/Edge.java
+++ b/src/org/twak/camp/Edge.java
@@ -32,6 +32,10 @@ import org.twak.utils.geom.LinearForm3D;
  */
 public class Edge
 {
+	
+	private static final double COLLINEAR_THRESHOLD = 0.01; // angle in radians
+	private static final double COS_THRESHOLD = Math.cos(COLLINEAR_THRESHOLD*COLLINEAR_THRESHOLD);
+	
     public Corner start, end;
 
     // 0 is straight up, positive/-ve is inwards/outwards, absolute value must be less than Math.PI/2
@@ -160,31 +164,84 @@ public class Edge
 
     public boolean isCollisionNearHoriz(Edge other)
     {
-    	Ray3d r = linearForm.collide( other.linearForm );
+    	Ray3d r = collide( other.linearForm );
     	
     	if (r == null)
     		return false;
     	
          return Math.abs( r.direction.z ) < 0.001;
     }
+    
+    private Ray3d collide(LinearForm3D other) {
+        // Plane 1: A*x + B*y + C*z + D = 0, so d1 = -D, n1 = (A, B, C)
+        // Plane 2: other.A*x + other.B*y + other.C*z + other.D = 0, so d2 = -other.D, n2 = (other.A, other.B, other.C)
+        double n1x = linearForm.A, n1y = linearForm.B, n1z = linearForm.C;
+        double n2x = other.A, n2y = other.B, n2z = other.C;
+        
+        // Compute the cross product: r = n1 x n2, the direction of the intersection line.
+        double rx = n1y * n2z - n1z * n2y;
+        double ry = n1z * n2x - n1x * n2z;
+        double rz = n1x * n2y - n1y * n2x;
+        
+        // If the two plane normals are (nearly) parallel, then r will be near 0.
+        double rnormSq = rx * rx + ry * ry + rz * rz;
+        if (rnormSq == 0) {
+            return null;
+        }
+        
+        // Compute d1 and d2 from the plane equations.
+        double d1 = -linearForm.D;
+        double d2 = -other.D;
+        
+        // Compute the vector w = d1*n2 - d2*n1.
+        double wx = d1 * n2x - d2 * n1x;
+        double wy = d1 * n2y - d2 * n1y;
+        double wz = d1 * n2z - d2 * n1z;
+        
+        // Now compute the particular solution point p = w x r / ||r||².
+        double px = wy * rz - wz * ry;
+        double py = wz * rx - wx * rz;
+        double pz = wx * ry - wy * rx;
+        
+        double invRnormSq = 1.0 / rnormSq;
+        px *= invRnormSq;
+        py *= invRnormSq;
+        pz *= invRnormSq;
+        
+        Point3d point = new Point3d(px, py, pz);
+        Vector3d direction = new Vector3d(rx, ry, rz);
+        return new Ray3d(point, direction);
+    }
 
-//    public boolean isParallel(Edge other)
-//    {
-//        Ray3d r = linearForm.collide( other.linearForm );
-//
-//        if (r == null)
-//            return true;
-//
-//        return Math.abs( r.direction.z ) < 0.001;
-//    }
+
+	public boolean isParallel(Edge other) {
+		return isAligned(uphill, other.uphill) && isAligned(direction(), other.direction());
+	}
+    
+	private static boolean isAligned(Vector3d v1, Vector3d v2) {
+		// Avoid division by zero
+		double lenSq1 = v1.lengthSquared();
+		double lenSq2 = v2.lengthSquared();
+		if (lenSq1 == 0.0 || lenSq2 == 0.0) {
+			return false;
+		}
+
+		// Compare squared quantities to avoid square root
+		double dotProduct = v1.dot(v2);
+		double squaredDot = dotProduct * dotProduct;
+		double threshold = COS_THRESHOLD * COS_THRESHOLD * lenSq1 * lenSq2;
+
+		return squaredDot >= threshold;
+	}
     
     /**
-     * Do these two edges go in the same direction and are they coliniear.
+     * Do these two edges go in the same direction and are they collinear?
      * (Are they parallel and go through the same point?)
      */
     public boolean sameDirectedLine( Edge nextL )
     {
-        return nextL.direction().angle( direction() ) < 0.01 && Math.abs( getAngle() - nextL.getAngle() ) < 0.01;
+    	return nextL.direction().angle( direction() ) < COLLINEAR_THRESHOLD && 
+    			Math.abs( getAngle() - nextL.getAngle() ) < COLLINEAR_THRESHOLD;
     }
 
     /**
@@ -355,11 +412,6 @@ public class Edge
     public static Tuple3d collide (Corner a, double height)
     {
         LinearForm3D ceiling = new LinearForm3D( 0, 0, 1, -height );
-
-        // this can cause Jama not to return...
-        if ( a.prevL.linearForm.hasNaN() || a.nextL.linearForm.hasNaN() )
-                    throw new Error();
-
             try {
                 return ceiling.collide(a.prevL.linearForm, a.nextL.linearForm);
             } catch (RuntimeException e) {

--- a/src/org/twak/camp/EdgeCollision.java
+++ b/src/org/twak/camp/EdgeCollision.java
@@ -55,9 +55,9 @@ public class EdgeCollision implements HeightEvent
     public int hashCode()
     {
         int hash = 3;
-        hash += ( this.a != null ? this.a.hashCode() : 0 );
-        hash += ( this.b != null ? this.b.hashCode() : 0 );
-        hash += ( this.c != null ? this.c.hashCode() : 0 );
+        hash+=this.a.hashCode();
+        hash+=this.b.hashCode();
+        hash+=this.c.hashCode();
         return hash * 31;
     }
 

--- a/src/org/twak/camp/EdgeSpatialIndex.java
+++ b/src/org/twak/camp/EdgeSpatialIndex.java
@@ -1,69 +1,54 @@
 package org.twak.camp;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import org.tinspin.index.rtree.RTree;
+import org.tinspin.index.rtree.RTreeEntry;
 
-//A very simple spatial index for edges using a coarse grid. In production you might use a proper k-d tree.
 public class EdgeSpatialIndex {
-	private Map<Integer, List<Edge>> grid = new HashMap<>();
-	private final double cellSize;
 
-	public EdgeSpatialIndex(double cellSize) {
-		this.cellSize = cellSize;
-	}
+	private final RTree<Edge> tree;
+	private final int size;
 
-	// Convert a point coordinate to grid cell id.
-	private int hash(double coord) {
-		return (int) Math.floor(coord / cellSize);
-	}
+	public EdgeSpatialIndex(Collection<Edge> edges) {
+		tree = RTree.createRStar(2);
+		size = edges.size();
+		RTreeEntry<Edge>[] boxes = new RTreeEntry[size];
+		int i = 0;
 
-	// We assume each edge has a bounding box (or can compute one) covering the
-	// edge's current extent.
-	// Here we assume edge.getBBox() returns a double[4] = {minX, minY, maxX, maxY}.
-	public void insert(Edge e) {
-		double[] bbox = e.getBBox();
-		int xStart = hash(bbox[0]), xEnd = hash(bbox[2]);
-		int yStart = hash(bbox[1]), yEnd = hash(bbox[3]);
-		for (int i = xStart; i <= xEnd; i++) {
-			for (int j = yStart; j <= yEnd; j++) {
-				int key = (i << 16) + j;
-				grid.computeIfAbsent(key, k -> new ArrayList<>()).add(e);
-			}
+		for (Edge e : edges) {
+			double[] bb = e.getBBox();
+			RTreeEntry<Edge> box = RTreeEntry.createBox(new double[] { bb[0], bb[1] }, new double[] { bb[2], bb[3] }, e);
+			boxes[i++] = box;
 		}
+
+		tree.load(boxes);
 	}
 
-	// Remove an edge from the index. (You might want to improve this for
-	// performance.)
-// public void remove(Edge e) {
-//     double[] bbox = e.getBBox(); 
-//     int xStart = hash(bbox[0]), xEnd = hash(bbox[2]);
-//     int yStart = hash(bbox[1]), yEnd = hash(bbox[3]);
-//     for (int i = xStart; i <= xEnd; i++) {
-//         for (int j = yStart; j <= yEnd; j++) {
-//             int key = (i << 16) + j;
-//             List<Edge> list = grid.get(key);
-//             if (list != null) list.remove(e);
-//         }
-//     }
-// }
+	/**
+	 * Searches for edges that intersect with the specified bounding box.
+	 */
+	public List<Edge> search(double minX, double minY, double maxX, double maxY) {
+		double[] min = new double[] { minX, minY };
+		double[] max = new double[] { maxX, maxY };
+		List<Edge> out = new ArrayList<>();
+		tree.queryIntersect(min, max).forEachRemaining(e -> out.add(e.value()));
+		return out;
+	}
 
-	// Returns candidate edges that lie in a specified search box.
-	public Set<Edge> search(double minX, double minY, double maxX, double maxY) {
-		Set<Edge> results = new HashSet<>();
-		int xStart = hash(minX), xEnd = hash(maxX);
-		int yStart = hash(minY), yEnd = hash(maxY);
-		for (int i = xStart; i <= xEnd; i++) {
-			for (int j = yStart; j <= yEnd; j++) {
-				int key = (i << 16) + j;
-				List<Edge> list = grid.get(key);
-				if (list != null)
-					results.addAll(list);
-			}
+	/**
+	 * Searches for the k nearest edges to the specified point.
+	 */
+	public List<Edge> search(double cX, double cY, int k) {
+		double[] center = new double[] { cX, cY };
+		List<Edge> out = new ArrayList<>();
+
+		if (k >= size) {
+			tree.iterator().forEachRemaining(e -> out.add(e.value()));
+		} else {
+			tree.queryKnn(center, k).forEachRemaining(e -> out.add(e.value()));
 		}
-		return results;
+		return out;
 	}
 }

--- a/src/org/twak/camp/EdgeSpatialIndex.java
+++ b/src/org/twak/camp/EdgeSpatialIndex.java
@@ -1,0 +1,69 @@
+package org.twak.camp;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+//A very simple spatial index for edges using a coarse grid. In production you might use a proper k-d tree.
+public class EdgeSpatialIndex {
+	private Map<Integer, List<Edge>> grid = new HashMap<>();
+	private final double cellSize;
+
+	public EdgeSpatialIndex(double cellSize) {
+		this.cellSize = cellSize;
+	}
+
+	// Convert a point coordinate to grid cell id.
+	private int hash(double coord) {
+		return (int) Math.floor(coord / cellSize);
+	}
+
+	// We assume each edge has a bounding box (or can compute one) covering the
+	// edge's current extent.
+	// Here we assume edge.getBBox() returns a double[4] = {minX, minY, maxX, maxY}.
+	public void insert(Edge e) {
+		double[] bbox = e.getBBox();
+		int xStart = hash(bbox[0]), xEnd = hash(bbox[2]);
+		int yStart = hash(bbox[1]), yEnd = hash(bbox[3]);
+		for (int i = xStart; i <= xEnd; i++) {
+			for (int j = yStart; j <= yEnd; j++) {
+				int key = (i << 16) + j;
+				grid.computeIfAbsent(key, k -> new ArrayList<>()).add(e);
+			}
+		}
+	}
+
+	// Remove an edge from the index. (You might want to improve this for
+	// performance.)
+// public void remove(Edge e) {
+//     double[] bbox = e.getBBox(); 
+//     int xStart = hash(bbox[0]), xEnd = hash(bbox[2]);
+//     int yStart = hash(bbox[1]), yEnd = hash(bbox[3]);
+//     for (int i = xStart; i <= xEnd; i++) {
+//         for (int j = yStart; j <= yEnd; j++) {
+//             int key = (i << 16) + j;
+//             List<Edge> list = grid.get(key);
+//             if (list != null) list.remove(e);
+//         }
+//     }
+// }
+
+	// Returns candidate edges that lie in a specified search box.
+	public Set<Edge> search(double minX, double minY, double maxX, double maxY) {
+		Set<Edge> results = new HashSet<>();
+		int xStart = hash(minX), xEnd = hash(maxX);
+		int yStart = hash(minY), yEnd = hash(maxY);
+		for (int i = xStart; i <= xEnd; i++) {
+			for (int j = yStart; j <= yEnd; j++) {
+				int key = (i << 16) + j;
+				List<Edge> list = grid.get(key);
+				if (list != null)
+					results.addAll(list);
+			}
+		}
+		return results;
+	}
+}

--- a/src/org/twak/camp/Skeleton.java
+++ b/src/org/twak/camp/Skeleton.java
@@ -74,6 +74,7 @@ public class Skeleton
     // lazy system for refinding all face events. true so we run it once at start
     boolean refindFaceEvents = true;
     
+    // number of nearest edges considered for corner-edge collision
     private int edgeNearestNeighbors = Integer.MAX_VALUE;
 
 	/**
@@ -273,7 +274,7 @@ public class Skeleton
                 if (height == c.z )
                     t = new Point3d(c);
                 else {
-                    if (preserveParallel && CollisionQ.isParallel( c.prevL, c.nextL ))  {
+                    if (preserveParallel && c.prevL.isParallel( c.nextL ))  {
 
                         Vector3d d = c.nextL.direction();
                         d.normalize( d );

--- a/src/org/twak/camp/Skeleton.java
+++ b/src/org/twak/camp/Skeleton.java
@@ -6,8 +6,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,557 +24,358 @@ import org.twak.utils.collections.LoopL;
 import org.twak.utils.collections.Loopable;
 import org.twak.utils.collections.Loopz;
 import org.twak.utils.collections.ManyManyMap;
-import org.twak.utils.collections.MultiMap;
 import org.twak.utils.collections.SetCorrespondence;
 import org.twak.utils.geom.LinearForm3D;
 
 /**
- * to debug: does it work at all (PointEditor)
- * Offset?
- * Horizontal Edges?
- * Height Collision.processHoriz()?
- *
- * Call 
- *  <pre>Skeleton skel = new Skeleton( edges );
- *  skel.skeleton();</pre>
- *
- * get output from
- * <pre>getOutput</pre>
- *
  * @author twak
  */
-public class Skeleton
-{
+public class Skeleton {
+	
     public boolean preserveParallel = false;
     public boolean volumeMaximising = true;
-	public Set<Corner> liveCorners = new LinkedHashSet<>();
-    public Set<Edge> liveEdges = new LinkedHashSet<>();
+    public Set<Corner> liveCorners = new HashSet<>();  // order not essential in production
+    public Set<Edge> liveEdges = new HashSet<>();
     public CollisionQ qu;
     public double height = 0;
     
+    // we store triplets of faces already created to prevent duplicates (order–insensitive)
+    public Set<EdgeCollision> seen = new HashSet<>();
     
-
-    // we store the triplets of faces we've already passed out to stop repeats (insensitive to face order)
-    public Set<EdgeCollision> seen = new LinkedHashSet<>();
-
     // output data
-//    public LoopL<Corner> flatTop = new LoopL<>();
-    public Output output = new Output( this );
+    public Output output = new Output(this);
     
     // debug
     public List<CoSitedCollision> debugCollisionOrder = new ArrayList<>();
-
-    public Map<Edge, Set<Tag>> planFeatures = new LinkedHashMap<>();
-
+    
+    public Map<Edge, Set<Tag>> planFeatures = new HashMap<>();
+    
     // for debugging
     public String name = "?";
-
-    // lazy system for refinding all face events. true so we run it once at start
+    
+    // lazy flag for re–finding all face events. true so we run it once at start
     boolean refindFaceEvents = true;
-
-    public Skeleton(){}
-
-    public Skeleton (LoopL<Corner> corners)
-    {
-        setup( corners );
+    
+    // (temporaries used in capCopy)
+    public DHash<Corner, Corner> cornerMap;
+    public ManyManyMap<Corner, Corner> segmentMap;
+    
+    public Skeleton() {}
+    
+    public Skeleton(LoopL<Corner> corners) {
+        setup(corners);
     }
-
+    
+    double cellSize = Double.MAX_VALUE;
+    
     /**
-     * @Deprecated
-     * @param input list of edges, edges shouldn't be repeated!
+     * Deprecated – given a loop of edges convert to corners.
      */
-    public Skeleton( LoopL<Edge> input, boolean javaGenericsAreABigPileOfShite )
-    {
-        setupForEdges(input);
+	public Skeleton(LoopL<Edge> input, double cellSize) {
+		this.cellSize = cellSize;
+		setupForEdges(input);
+	}
+
+	public Skeleton(LoopL<Edge> input, boolean javaGenericsAreABigPileOfShite) {
+		setupForEdges(input);
+	}
+
+	public Skeleton(LoopL<Corner> input, double cap, boolean javaGenericsAreABigPileOfShite) {
+		setup(input);
+		capAt(cap);
     }
-
-
+    
+//    public Skeleton(LoopL<Edge> input, final double cap) {
+//        setupForEdges(input);
+//        capAt(cap);
+//    }
+    
     /**
-     * @param cap height (flat-topped skeleton) to finish at
+     * Converts loops of edges (BAD!) to loops of corners (GOOD!)
      */
-    public Skeleton(LoopL<Corner> input, double cap, boolean javaGenericsAreABigPileOfShite) {
-        setup(input);
-
-        capAt(cap);
-    }	
-
-    /**
-     * @Deprecated
-     * @param cap height (flat-topped skeleton) to finish at
-     */
-    public Skeleton( LoopL<Edge> input, final double cap )
-    {
-        setupForEdges(input);
-
-        capAt(cap);
-    }
-
-    /**
-     * Stop-gap measure to convert loops of edges (BAD!) to loops of corners (GOOD!)
-     * @param input
-     */
-    public void setupForEdges (LoopL<Edge> input)
-    {
+    public void setupForEdges(LoopL<Edge> input) {
         LoopL<Corner> corners = new LoopL<>();
-        for (Loop<Edge> le : input) //input.count()
-        {
-            Loop<Corner> lc = new Loop<Corner>();
+        // Pre–allocate the inner loops where possible.
+        for (Loop<Edge> le : input) {
+            Loop<Corner> lc = new Loop<>();
             corners.add(lc);
-            for (Edge e : le)
-            {
-                lc.append( e.start);
+            for (Edge e : le) {
+                lc.append(e.start);
                 e.start.nextL = e;
                 e.end.prevL = e;
                 e.start.nextC = e.end;
                 e.end.prevC = e.start;
             }
         }
-
-        setup (corners); //corners.count()
+        setup(corners);
     }
-
+    
     /**
      * Sanitize input
-     * @param input
      */
-    public void setup( LoopL<Corner> input )
-    {
-        // reset all! (not needed...but maybe in future)
-        height =0;
-        liveCorners.clear(); 
+    public void setup(LoopL<Corner> input) {
+        height = 0;
+        liveCorners.clear();
         liveEdges.clear();
-
-        MultiMap<Edge, Corner> allEdges= new MultiMap<>();
-
-        for (Corner c : input.eIterator()) // input.count()
-            allEdges.put( c.nextL, c );
-
-        // combine shared edges into single output faces
-        for ( Edge e : allEdges.keySet() ) //allEdges.size()
-        {
+        
+        // Use a HashMap instead of a MultiMap if order isn’t essential (faster access)
+        Map<Edge, List<Corner>> allEdges = new HashMap<>();
+        
+        for (Corner c : input.eIterator()) {
+            List<Corner> list = allEdges.get(c.nextL);
+            if (list == null) {
+                list = new ArrayList<>();
+                allEdges.put(c.nextL, list);
+            }
+            list.add(c);
+        }
+        
+        // Combine shared edges (each edge appears once in output)
+        for (Edge e : allEdges.keySet()) {
             e.currentCorners.clear();
-            List<Corner> corners = allEdges.get( e );
-            Corner first = corners.get( 0 );
-
-            output.newEdge( first.nextL, null, new LinkedHashSet<>() );
-
-            // why don't we need this?
-//            for (Corner c : corners)
-//                output.newDefiningSegment( first );
-
-            // not sure this is right
-            for (int i = 1; i < corners.size(); i++)
-                output.merge( first, corners.get( i ) );
-
+            List<Corner> corners = allEdges.get(e);
+            Corner first = corners.get(0);
+            output.newEdge(first.nextL, null, new HashSet<>());
+            
+            // Merge all definitions
+            for (int i = 1; i < corners.size(); i++) {
+                output.merge(first, corners.get(i));
+            }
+            
             liveEdges.add(e);
         }
-
-        for (Corner c : input.eIterator())
-        {
-            if (c.z != 0 || c.nextL == null || c.prevL == null) // fixme: threading bug with chordatlas under openJDK11 causes npes on nextL?
+        
+        for (Corner c : input.eIterator()) {
+            if (c.z != 0 || c.nextL == null || c.prevL == null)
                 throw new Error("Error in input");
-
-            output.newDefiningSegment( c );
-            liveCorners.add(c );
+            output.newDefiningSegment(c);
+            liveCorners.add(c);
             c.nextL.currentCorners.add(c);
             c.prevL.currentCorners.add(c);
         }
-
-        qu = new CollisionQ( this ); // yay closely coupled classes
-
-        for ( Edge e : allEdges.keySet() )
-        {
-            e.machine.addEdge( e, this );
+        
+        qu = new CollisionQ(this, cellSize);
+        
+        // Add edges to their machines (accelerated structure)
+        for (Edge e : allEdges.keySet()) {
+            e.machine.addEdge(e, this);
         }
-
-        // now all angles are set, find initial set of intersections (will remove corners if parallel enough)
+        
         refindFaceEventsIfNeeded();
-//        qu.dump(); // debug
     }
-
+    
     /**
-     * Execute the skeleton algorithm
+     * Execute the skeleton algorithm.
      */
-    public void skeleton()
-    {
+    public void skeleton() {
         validate();
         HeightEvent he;
-
         int i = 0;
-
-        DebugDevice.dump("main "+String.format("%4d", ++i ), this );
-        while ( ( he = qu.poll() ) != null )
-            try
-            {
-                if ( he.process( this ) ) // business happens here
-                {
+        DebugDevice.dump("main " + String.format("%4d", ++i), this);
+        while ((he = qu.poll()) != null) {
+            try {
+                if (he.process(this)) {
                     height = he.getHeight();
-                    DebugDevice.dump("main "+height+" "+String.format("%4d", ++i ), this );
+                    DebugDevice.dump("main " + height + " " + String.format("%4d", ++i), this);
                     validate();
                 }
-                
                 refindFaceEventsIfNeeded();
-            }
-            catch ( Throwable t )
-            {
+            } catch (Throwable t) {
                 t.printStackTrace();
-                if (t.getCause() != null)
-                {
+                if (t.getCause() != null) {
                     System.out.println(" caused by:");
                     t.getCause().printStackTrace();
                 }
             }
-
-        DebugDevice.dump("after main "+String.format("%4d", ++i ), this );
-
-        // build output polygons from constructed graph
-        output.calculate( this );
+        }
+        DebugDevice.dump("after main " + String.format("%4d", ++i), this);
+        
+        output.calculate(this);
     }
-
+    
     /**
-     * This method returns a set of edges representing a horizontal slice through the skeleton
-     * at the specified height (given that no other events happen bewteen current height and given cap height).
-     *
-     * Topology assumed final - eg - we take a copy at of the slice at the given height, not processing any more height events
-     *
-     * Non destructive - this doesn't change the skeleton. This routine is for taking output mid-way through evaluation.
-     *
-     * All output edges have the same machines as their originators.
+     * Returns a set of edges representing a horizontal slice through the skeleton at the specified height.
+     * Non–destructive.
      */
-    
-    public DHash<Corner,Corner> cornerMap; // contains lookup for results (new->old)
-    public ManyManyMap<Corner,Corner> segmentMap; // contains lookup for results ( old -> new )
-    
-    public LoopL<Corner> capCopy (double height)
-    {
-        segmentMap = new ManyManyMap<Corner, Corner>();
+    public LoopL<Corner> capCopy(double height) {
+        segmentMap = new ManyManyMap<>();
         cornerMap = new DHash<>();
-
-        LinearForm3D ceiling = new LinearForm3D( 0, 0, 1, -height );
-
-        for (Corner c : liveCorners)
-        {
-
+        
+        LinearForm3D ceiling = new LinearForm3D(0, 0, 1, -height);
+        
+        // Use a standard for–each; minimal allocation per corner.
+        for (Corner c : liveCorners) {
             try {
                 Tuple3d t;
-
-                // don't introduce instabilities if height is already as requested.
-                if (height == c.z )
+                if (height == c.z)
                     t = new Point3d(c);
                 else {
-                    if (preserveParallel && CollisionQ.isParallel( c.prevL, c.nextL ))  {
-
+                    if (preserveParallel && CollisionQ.isParallel(c.prevL, c.nextL)) {
                         Vector3d d = c.nextL.direction();
-                        d.normalize( d );
-                        LinearForm3D parallel = new LinearForm3D( d, c );
-                        t = ceiling.collide( c.prevL.linearForm, parallel );
-                    }
-                    else {
-                        t = ceiling.collide( c.prevL.linearForm, c.nextL.linearForm );
+                        d.normalize(d);
+                        LinearForm3D parallel = new LinearForm3D(d, c);
+                        t = ceiling.collide(c.prevL.linearForm, parallel);
+                    } else {
+                        t = ceiling.collide(c.prevL.linearForm, c.nextL.linearForm);
                     }
                 }
-
                 cornerMap.put(new Corner(t), c);
             } catch (RuntimeException e) {
-                //assume, they're all coincident?
-                cornerMap.put (new Corner (c.x, c.y, height), c);
+                cornerMap.put(new Corner(c.x, c.y, height), c);
             }
         }
-
-         Cache<Corner, Edge> edgeCache = new Cache<Corner, Edge>()
-         {
-             Map<Edge, Edge> lowToHighEdge = new HashMap<>();
-
+        
+        // Cache to re–use elevated edges
+        Cache<Corner, Edge> edgeCache = new Cache<Corner, Edge>() {
+            Map<Edge, Edge> lowToHighEdge = new HashMap<>();
             @Override
-            /**
-             * @param i the low corner
-             */
-            public Edge create( Corner i )
-            {
-//                Edge cached = lowToHighEdge.get (i.nextL);
-
-                // the following two lines reuse an edge when it is referenced twice. this seems like the better way to do it, but our triangulator can't currently handle two-separate loops of vertices
-//                if (cached != null)
-//                    return cached; // this was one edge, (i.nextL), the raised copy will also be one edge
-
-                Edge edge = new Edge ( cornerMap.teg(i), cornerMap.teg(i.nextC) );
-
+            public Edge create(Corner i) {
+                // re–use edge if possible
+                Edge edge = new Edge(cornerMap.teg(i), cornerMap.teg(i.nextC));
                 lowToHighEdge.put(i.nextL, edge);
-
-                edge.setAngle( i.nextL.getAngle() );
-                edge.machine = i.nextL.machine; // nextL is null when we have a non root global
-
+                edge.setAngle(i.nextL.getAngle());
+                edge.machine = i.nextL.machine;
                 return edge;
             }
-         };
-
+        };
+        
         LoopL<Corner> out = new LoopL<>();
-
-        Set<Corner> workingSet = new LinkedHashSet<> ( liveCorners );
-        while (!workingSet.isEmpty())
-        {
+        Set<Corner> workingSet = new HashSet<>(liveCorners);
+        while (!workingSet.isEmpty()) {
             Loop<Corner> loop = new Loop<>();
-            out.add( loop );
+            out.add(loop);
             Corner current = workingSet.iterator().next();
-            do
-            {
-                Corner s = cornerMap.teg( current ),
-                       e  = cornerMap.teg( current.nextC );
-
-                // one edge may have two segments, but the topology will not change between old and new,
-                // so we may store the leading corner to match segments
-                segmentMap.addForwards( current, s );
-
-                Edge edge = edgeCache.get( current );
-
-                loop.append( s );
+            do {
+                Corner s = cornerMap.teg(current), e = cornerMap.teg(current.nextC);
+                segmentMap.addForwards(current, s);
+                Edge edge = edgeCache.get(current);
+                loop.append(s);
                 s.nextC = e;
                 e.prevC = s;
                 s.nextL = edge;
                 e.prevL = edge;
-
-                workingSet.remove( current );
+                workingSet.remove(current);
                 current = current.nextC;
-            }
-            while (workingSet.contains( current ));
+            } while (workingSet.contains(current));
         }
-        
         return out;
     }
-
-    public Cache<Corner, Collection<Corner>> getSegmentOriginator()
-    {
+    
+    public Cache<Corner, Collection<Corner>> getSegmentOriginator() {
         return output.getSegmentOriginator();
     }
-
-    // when a face is parented, it is flagged here. this allows overriding classes to get even process this information
-    public void parent( Face child, Face parent ) // parent is below (older than) child...
-    {
-        //override me
+    
+    public void parent(Face child, Face parent) {
+        // override me if needed
     }
-
-    public static class SEC
-    {
+    
+    public static class SEC {
         Corner start, end;
         Edge nextL, edge, prevL;
-
-        public SEC(Corner start, Edge edge)
-        {
+        public SEC(Corner start, Edge edge) {
             this.start = start;
             end = start.nextC;
             prevL = start.prevL;
             nextL = end.nextL;
-
             this.edge = edge;
         }
     }
     
-    
     public interface HeresTheArea {
-    	public void heresTheArea(double area);
-    }
-
-    public void capAt (double cap) {
-    	capAt (cap, null);
-    	
-    }
-    public void capAt (double cap, HeresTheArea hta) {
-    	
-    	  qu.add(new HeightEvent() {
-
-    		  public double getHeight() {
-                  return cap;
-              }
-
-              public boolean process(Skeleton skel) {
-            	  
-                  SkeletonCapUpdate capUpdate = new SkeletonCapUpdate(skel);
-
-                  
-                  LoopL<Corner> flatTop = capUpdate.getCap(cap);
-                  
-                  capUpdate.update(new LoopL<>(), new SetCorrespondence<Corner, Corner>(), new DHash<Corner, Corner>());
-                  
-                  LoopL<Point3d> togo =
-                          flatTop.new Map<Point3d>()
-                          {
-                              @Override
-                              public Point3d map( Loopable<Corner> input )
-                              {
-                                  return new Point3d( input.get().x, input.get().y, input.get().z );
-                              }
-                          }.run();
-                          skel.output.addNonSkeletonOutputFace( togo, new Vector3d( 0, 0, 1 ) );
-                          
-                          if (hta != null)
-                        	  hta.heresTheArea( Loopz.area3( togo ) );
-                          
-                  DebugDevice.dump("post cap dump", skel);
-
-                  skel.qu.clearFaceEvents();
-                  skel.qu.clearOtherEvents();
-                  
-                  return true;
-              }
-          });
+        public void heresTheArea(double area);
     }
     
-    public void refindAllFaceEventsLater()
-    {
+    public void capAt(double cap) {
+        capAt(cap, null);
+    }
+    
+    public void capAt(double cap, HeresTheArea hta) {
+        qu.add(new HeightEvent() {
+            public double getHeight() {
+                return cap;
+            }
+            public boolean process(Skeleton skel) {
+                SkeletonCapUpdate capUpdate = new SkeletonCapUpdate(skel);
+                LoopL<Corner> flatTop = capUpdate.getCap(cap);
+                capUpdate.update(new LoopL<>(), new SetCorrespondence<Corner, Corner>(), new DHash<Corner, Corner>());
+                LoopL<Point3d> togo = flatTop.new Map<Point3d>() {
+                    @Override
+                    public Point3d map(Loopable<Corner> input) {
+                        return new Point3d(input.get().x, input.get().y, input.get().z);
+                    }
+                }.run();
+                skel.output.addNonSkeletonOutputFace(togo, new Vector3d(0, 0, 1));
+                if (hta != null)
+                    hta.heresTheArea(Loopz.area3(togo));
+                
+                DebugDevice.dump("post cap dump", skel);
+                skel.qu.clearFaceEvents();
+                skel.qu.clearOtherEvents();
+                return true;
+            }
+        });
+    }
+    
+    public void refindAllFaceEventsLater() {
         refindFaceEvents = true;
     }
-
-    private void refindFaceEventsIfNeeded()
-    {
-        // on demand
+    
+    private void refindFaceEventsIfNeeded() {
         if (!refindFaceEvents)
             return;
-
-        /**
-         * Very expensive part - refind all collisions (including those already processed)
-         * MachineEvents remain in their current state
-         *
-         * should really only be done for those edges that have changed
-         */
-
-        // context collects events that must be processed immediately following (eg horizontals...)
-         HeightCollision context = new HeightCollision();
-
-//        qu.clearFaceEvents();
-        for ( Corner lc : new CloneConfirmIterator<Corner>(liveCorners) )
-            qu.addCorner( lc, context, true );
-
-        // if we are not adding new events (and this isn't adding the input the first time)
-        // this shouldn't do anything
-        context.processHoriz( this );
-		refindFaceEvents = false;
+        
+        HeightCollision context = new HeightCollision();
+        for (Corner lc : new CloneConfirmIterator<>(liveCorners))
+            qu.addCorner(lc, context, true);
+        context.processHoriz(this);
+        refindFaceEvents = false;
     }
-
-    /**
-     * Debug!
-     */
-    public void validate()
-    {
-        if (false)
-        {
-        Set <Corner> all = new LinkedHashSet<> ( liveCorners );
-        outer:
-        while (!all.isEmpty())
-        {
-            Corner start = all.iterator().next();
-            all.remove(start);
-
-            Corner next = start;
-
-            int count = 0;
-
-            do
-            {
-                count ++;
-                Corner c = next.nextC;
-                all.remove( c );
-
-                Edge e = next.nextL;
-                try
-                {
-                    assert ( c.nextC.prevC == c );
-                    assert ( c.prevC.nextC == c );
-
-                    assert (c.prevL == e);
-                    assert (c.prevC.nextL == e);
-
-//                    assert ( e.start.nextC == e.end );
-//                    assert ( e.end.prevC == e.start ); liveEdges.contains(e)
-                    for (Corner d : liveCorners)
-                    {
-                        if (d.nextL == e || d.prevL == e)
-                            assert ( e.currentCorners.contains( d ) );
-                        else
-                            assert ( !e.currentCorners.contains( d ) );
-                    }
-
-                    for ( Corner d : e.currentCorners )
-                        assert ( liveCorners.contains( d ) );
-
-                    assert (count < 100);
-                }
-                catch ( AssertionError f )
-                {
-                    System.err.println( " on edge is "+e);
-                    System.err.println( " validate error on corner " + c + "  on line " + f.getStackTrace()[0].getLineNumber() );
-                    f.printStackTrace();
-                }
-                finally
-                {
-                    if (count > 100)
-                        continue outer;
-                }
-
-                next = c;
-            }
-            while (next != start);
-        }
+    
+    public void validate() {
+        if (false) {
+            // same debug routine as before…
         }
     }
-
-    public void setPlanTags (Edge edge, Set<Tag> features)
-    {
-        planFeatures.put( edge, features );
+    
+    public void setPlanTags(Edge edge, Set<Tag> features) {
+        planFeatures.put(edge, features);
     }
-
-    public Set<Tag> getPlanTags( Edge originator )
-    {
-        return planFeatures.get( originator );
+    
+    public Set<Tag> getPlanTags(Edge originator) {
+        return planFeatures.get(originator);
     }
-
-    public Comparator<Edge> getHorizontalComparator()
-    {
-        return new Comparator<Edge>()
-        {
-            /**
-             * Volume maximizing resolution
-             */
-            public int compare( Edge o1, Edge o2 )
-            {
-                if ( volumeMaximising )
-                    return Double.compare( o1.getAngle(), o2.getAngle() );
-                else
-                    return Double.compare( o2.getAngle(), o1.getAngle() );
-            }
+    
+    public Comparator<Edge> getHorizontalComparator() {
+        return (o1, o2) -> {
+            if (volumeMaximising)
+                return Double.compare(o1.getAngle(), o2.getAngle());
+            else
+                return Double.compare(o2.getAngle(), o1.getAngle());
         };
     }
-
-    public LoopL<Corner> findLoopLive()
-    {
-        LoopL<Corner> out = new LoopL<Corner>();
+    
+    public LoopL<Corner> findLoopLive() {
+        LoopL<Corner> out = new LoopL<>();
         Set<Corner> togo = new HashSet<>(liveCorners);
-
-        while (!togo.isEmpty())
-        {
+        while (!togo.isEmpty()) {
             Loop<Corner> loop = new Loop<>();
             out.add(loop);
-
             Corner start = togo.iterator().next();
-
             Corner current = start;
             int handbrake = 0;
-            do
-            {
+            do {
                 togo.remove(current);
                 loop.append(current);
-
                 current = current.nextC;
-            }
-            while (current !=start && handbrake++ < 1000);
-
-            if (handbrake >= 1000)
-            {
+                handbrake++;
+            } while (current != start && handbrake < 1000);
+            
+            if (handbrake >= 1000) {
                 System.err.println("broken loops in findLiveLoop");
                 Thread.dumpStack();
             }
         }
-
-        return out; //out.count();
-
+        return out;
     }
-}        
+}
+       

--- a/src/org/twak/camp/Skeleton.java
+++ b/src/org/twak/camp/Skeleton.java
@@ -96,6 +96,29 @@ public class Skeleton
         setupForEdges(input);
     }
     
+	/**
+	 * Creates a skeleton that uses a spatial index to optimise collision detection
+	 * between corners and edges. Instead of checking all edges for collisions, the
+	 * spatial index limits the search to a subset of nearby edges, which can
+	 * significantly improve performance. This optimisation is particularly useful
+	 * for large inputs, but its robustness depends on the input geometry and the
+	 * chosen number of nearest neighbors.
+	 * <p>
+	 * The spatial index reduces the number of edge checks, but it does not
+	 * guarantee completeness. If too few neighbors are considered, collisions may
+	 * be missed, leading to incorrect or broken output. The optimal number of
+	 * neighbors varies depending on the input: highly concave shapes may work with
+	 * fewer neighbors (as low as 8), while more complex or irregular shapes may
+	 * require a higher number to ensure accurate results.
+	 * 
+	 * @param input                The input loop of edges that define the skeleton.
+	 * @param edgeNearestNeighbors The number of nearest neighboring edges to
+	 *                             consider when searching for collisions using the
+	 *                             spatial index. This parameter balances
+	 *                             performance and correctness: too few neighbors
+	 *                             may miss collisions, while too many may reduce
+	 *                             the performance benefits of the spatial index.
+	 */
 	public Skeleton(LoopL<Edge> input, int edgeNearestNeighbors) {
 		this.edgeNearestNeighbors = edgeNearestNeighbors;
 		setupForEdges(input);

--- a/src/org/twak/camp/Skeleton.java
+++ b/src/org/twak/camp/Skeleton.java
@@ -6,6 +6,8 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,357 +26,566 @@ import org.twak.utils.collections.LoopL;
 import org.twak.utils.collections.Loopable;
 import org.twak.utils.collections.Loopz;
 import org.twak.utils.collections.ManyManyMap;
+import org.twak.utils.collections.MultiMap;
 import org.twak.utils.collections.SetCorrespondence;
 import org.twak.utils.geom.LinearForm3D;
 
 /**
+ * to debug: does it work at all (PointEditor)
+ * Offset?
+ * Horizontal Edges?
+ * Height Collision.processHoriz()?
+ *
+ * Call 
+ *  <pre>Skeleton skel = new Skeleton( edges );
+ *  skel.skeleton();</pre>
+ *
+ * get output from
+ * <pre>getOutput</pre>
+ *
  * @author twak
  */
-public class Skeleton {
-	
+public class Skeleton
+{
     public boolean preserveParallel = false;
     public boolean volumeMaximising = true;
-    public Set<Corner> liveCorners = new HashSet<>();
-    public Set<Edge> liveEdges = new HashSet<>();
+	public Set<Corner> liveCorners = new LinkedHashSet<>();
+    public Set<Edge> liveEdges = new LinkedHashSet<>();
     public CollisionQ qu;
     public double height = 0;
     
-    // we store triplets of faces already created to prevent duplicates (order–insensitive)
-    public Set<EdgeCollision> seen = new HashSet<>();
     
+
+    // we store the triplets of faces we've already passed out to stop repeats (insensitive to face order)
+    public Set<EdgeCollision> seen = new LinkedHashSet<>();
+
     // output data
-    public Output output = new Output(this);
+//    public LoopL<Corner> flatTop = new LoopL<>();
+    public Output output = new Output( this );
     
     // debug
     public List<CoSitedCollision> debugCollisionOrder = new ArrayList<>();
-    
-    public Map<Edge, Set<Tag>> planFeatures = new HashMap<>();
-    
+
+    public Map<Edge, Set<Tag>> planFeatures = new LinkedHashMap<>();
+
     // for debugging
     public String name = "?";
-    
-    // lazy flag for re–finding all face events. true so we run it once at start
+
+    // lazy system for refinding all face events. true so we run it once at start
     boolean refindFaceEvents = true;
     
-    // (temporaries used in capCopy)
-    public DHash<Corner, Corner> cornerMap;
-    public ManyManyMap<Corner, Corner> segmentMap;
-    
-    public Skeleton() {}
-    
-    public Skeleton(LoopL<Corner> corners) {
-        setup(corners);
+    private int edgeNearestNeighbors = Integer.MAX_VALUE;
+
+	/**
+	 * Deprecated – given a loop of edges convert to corners.
+	 */
+    public Skeleton(){}
+
+    public Skeleton (LoopL<Corner> corners)
+    {
+        setup( corners );
+    }
+
+    /**
+     * @Deprecated
+     * @param input list of edges, edges shouldn't be repeated!
+     */
+    public Skeleton( LoopL<Edge> input, boolean javaGenericsAreABigPileOfShite )
+    {
+        setupForEdges(input);
     }
     
-    private int edgeNearestNeighbors = Integer.MAX_VALUE;
-    
-    /**
-     * Deprecated – given a loop of edges convert to corners.
-     */
 	public Skeleton(LoopL<Edge> input, int edgeNearestNeighbors) {
 		this.edgeNearestNeighbors = edgeNearestNeighbors;
 		setupForEdges(input);
 	}
 
-	public Skeleton(LoopL<Edge> input, boolean javaGenericsAreABigPileOfShite) {
-		setupForEdges(input);
-	}
+    /**
+     * @param cap height (flat-topped skeleton) to finish at
+     */
+    public Skeleton(LoopL<Corner> input, double cap, boolean javaGenericsAreABigPileOfShite) {
+        setup(input);
 
-	public Skeleton(LoopL<Corner> input, double cap, boolean javaGenericsAreABigPileOfShite) {
-		setup(input);
-		capAt(cap);
-    }
-    
-    public Skeleton(LoopL<Edge> input, final double cap) {
+        capAt(cap);
+    }	
+
+    /**
+     * @Deprecated
+     * @param cap height (flat-topped skeleton) to finish at
+     */
+    public Skeleton( LoopL<Edge> input, final double cap )
+    {
         setupForEdges(input);
+
         capAt(cap);
     }
-    
+
     /**
-     * Converts loops of edges (BAD!) to loops of corners (GOOD!)
+     * Stop-gap measure to convert loops of edges (BAD!) to loops of corners (GOOD!)
+     * @param input
      */
-    public void setupForEdges(LoopL<Edge> input) {
+    public void setupForEdges (LoopL<Edge> input)
+    {
         LoopL<Corner> corners = new LoopL<>();
-        // Pre–allocate the inner loops where possible.
-        for (Loop<Edge> le : input) {
-            Loop<Corner> lc = new Loop<>();
+        for (Loop<Edge> le : input) //input.count()
+        {
+            Loop<Corner> lc = new Loop<Corner>();
             corners.add(lc);
-            for (Edge e : le) {
-                lc.append(e.start);
+            for (Edge e : le)
+            {
+                lc.append( e.start);
                 e.start.nextL = e;
                 e.end.prevL = e;
                 e.start.nextC = e.end;
                 e.end.prevC = e.start;
             }
         }
-        setup(corners);
+
+        setup (corners); //corners.count()
     }
-    
+
     /**
      * Sanitize input
+     * @param input
      */
-    public void setup(LoopL<Corner> input) {
-        height = 0;
-        liveCorners.clear();
+    public void setup( LoopL<Corner> input )
+    {
+        // reset all! (not needed...but maybe in future)
+        height =0;
+        liveCorners.clear(); 
         liveEdges.clear();
-        
-        // Use a HashMap instead of a MultiMap if order isn’t essential (faster access)
-        Map<Edge, List<Corner>> allEdges = new HashMap<>();
-        
-        for (Corner c : input.eIterator()) {
-            List<Corner> list = allEdges.get(c.nextL);
-            if (list == null) {
-                list = new ArrayList<>();
-                allEdges.put(c.nextL, list);
-            }
-            list.add(c);
-        }
-        
-        // Combine shared edges (each edge appears once in output)
-        for (Edge e : allEdges.keySet()) {
+
+        MultiMap<Edge, Corner> allEdges= new MultiMap<>();
+
+        for (Corner c : input.eIterator()) // input.count()
+            allEdges.put( c.nextL, c );
+
+        // combine shared edges into single output faces
+        for ( Edge e : allEdges.keySet() ) //allEdges.size()
+        {
             e.currentCorners.clear();
-            List<Corner> corners = allEdges.get(e);
-            Corner first = corners.get(0);
-            output.newEdge(first.nextL, null, new HashSet<>());
-            
-            // Merge all definitions
-            for (int i = 1; i < corners.size(); i++) {
-                output.merge(first, corners.get(i));
-            }
-            
+            List<Corner> corners = allEdges.get( e );
+            Corner first = corners.get( 0 );
+
+            output.newEdge( first.nextL, null, new LinkedHashSet<>() );
+
+            // why don't we need this?
+//            for (Corner c : corners)
+//                output.newDefiningSegment( first );
+
+            // not sure this is right
+            for (int i = 1; i < corners.size(); i++)
+                output.merge( first, corners.get( i ) );
+
             liveEdges.add(e);
         }
-        
-        for (Corner c : input.eIterator()) {
-            if (c.z != 0 || c.nextL == null || c.prevL == null)
+
+        for (Corner c : input.eIterator())
+        {
+            if (c.z != 0 || c.nextL == null || c.prevL == null) // fixme: threading bug with chordatlas under openJDK11 causes npes on nextL?
                 throw new Error("Error in input");
-            output.newDefiningSegment(c);
-            liveCorners.add(c);
+
+            output.newDefiningSegment( c );
+            liveCorners.add(c );
             c.nextL.currentCorners.add(c);
             c.prevL.currentCorners.add(c);
         }
-        
-        qu = new CollisionQ(this, edgeNearestNeighbors);
-        
-        // Add edges to their machines (accelerated structure)
-        for (Edge e : allEdges.keySet()) {
-            e.machine.addEdge(e, this);
+
+        qu = new CollisionQ( this, edgeNearestNeighbors ); // yay closely coupled classes
+
+        for ( Edge e : allEdges.keySet() )
+        {
+            e.machine.addEdge( e, this );
         }
-        
+
+        // now all angles are set, find initial set of intersections (will remove corners if parallel enough)
         refindFaceEventsIfNeeded();
+//        qu.dump(); // debug
     }
-    
+
     /**
-     * Execute the skeleton algorithm.
+     * Execute the skeleton algorithm
      */
-    public void skeleton() {
+    public void skeleton()
+    {
         validate();
         HeightEvent he;
+
         int i = 0;
-        DebugDevice.dump("main " + String.format("%4d", ++i), this);
-        while ((he = qu.poll()) != null) {
-            try {
-                if (he.process(this)) {
+
+        DebugDevice.dump("main "+String.format("%4d", ++i ), this );
+        while ( ( he = qu.poll() ) != null )
+            try
+            {
+                if ( he.process( this ) ) // business happens here
+                {
                     height = he.getHeight();
-                    DebugDevice.dump("main " + height + " " + String.format("%4d", ++i), this);
+                    DebugDevice.dump("main "+height+" "+String.format("%4d", ++i ), this );
                     validate();
                 }
+                
                 refindFaceEventsIfNeeded();
-            } catch (Throwable t) {
+            }
+            catch ( Throwable t )
+            {
                 t.printStackTrace();
-                if (t.getCause() != null) {
+                if (t.getCause() != null)
+                {
                     System.out.println(" caused by:");
                     t.getCause().printStackTrace();
                 }
             }
-        }
-        DebugDevice.dump("after main " + String.format("%4d", ++i), this);
-        
-        output.calculate(this);
+
+        DebugDevice.dump("after main "+String.format("%4d", ++i ), this );
+
+        // build output polygons from constructed graph
+        output.calculate( this );
     }
-    
+
     /**
-     * Returns a set of edges representing a horizontal slice through the skeleton at the specified height.
-     * Non–destructive.
+     * This method returns a set of edges representing a horizontal slice through the skeleton
+     * at the specified height (given that no other events happen bewteen current height and given cap height).
+     *
+     * Topology assumed final - eg - we take a copy at of the slice at the given height, not processing any more height events
+     *
+     * Non destructive - this doesn't change the skeleton. This routine is for taking output mid-way through evaluation.
+     *
+     * All output edges have the same machines as their originators.
      */
-    public LoopL<Corner> capCopy(double height) {
-        segmentMap = new ManyManyMap<>();
+    
+    public DHash<Corner,Corner> cornerMap; // contains lookup for results (new->old)
+    public ManyManyMap<Corner,Corner> segmentMap; // contains lookup for results ( old -> new )
+    
+    public LoopL<Corner> capCopy (double height)
+    {
+        segmentMap = new ManyManyMap<Corner, Corner>();
         cornerMap = new DHash<>();
-        
-        LinearForm3D ceiling = new LinearForm3D(0, 0, 1, -height);
-        
-        // Use a standard for–each; minimal allocation per corner.
-        for (Corner c : liveCorners) {
+
+        LinearForm3D ceiling = new LinearForm3D( 0, 0, 1, -height );
+
+        for (Corner c : liveCorners)
+        {
+
             try {
                 Tuple3d t;
-                if (height == c.z)
+
+                // don't introduce instabilities if height is already as requested.
+                if (height == c.z )
                     t = new Point3d(c);
                 else {
-                    if (preserveParallel && CollisionQ.isParallel(c.prevL, c.nextL)) {
+                    if (preserveParallel && CollisionQ.isParallel( c.prevL, c.nextL ))  {
+
                         Vector3d d = c.nextL.direction();
-                        d.normalize(d);
-                        LinearForm3D parallel = new LinearForm3D(d, c);
-                        t = ceiling.collide(c.prevL.linearForm, parallel);
-                    } else {
-                        t = ceiling.collide(c.prevL.linearForm, c.nextL.linearForm);
+                        d.normalize( d );
+                        LinearForm3D parallel = new LinearForm3D( d, c );
+                        t = ceiling.collide( c.prevL.linearForm, parallel );
+                    }
+                    else {
+                        t = ceiling.collide( c.prevL.linearForm, c.nextL.linearForm );
                     }
                 }
+
                 cornerMap.put(new Corner(t), c);
             } catch (RuntimeException e) {
-                cornerMap.put(new Corner(c.x, c.y, height), c);
+                //assume, they're all coincident?
+                cornerMap.put (new Corner (c.x, c.y, height), c);
             }
         }
-        
-        // Cache to re–use elevated edges
-        Cache<Corner, Edge> edgeCache = new Cache<Corner, Edge>() {
-            Map<Edge, Edge> lowToHighEdge = new HashMap<>();
+
+         Cache<Corner, Edge> edgeCache = new Cache<Corner, Edge>()
+         {
+             Map<Edge, Edge> lowToHighEdge = new HashMap<>();
+
             @Override
-            public Edge create(Corner i) {
-                // re–use edge if possible
-                Edge edge = new Edge(cornerMap.teg(i), cornerMap.teg(i.nextC));
+            /**
+             * @param i the low corner
+             */
+            public Edge create( Corner i )
+            {
+//                Edge cached = lowToHighEdge.get (i.nextL);
+
+                // the following two lines reuse an edge when it is referenced twice. this seems like the better way to do it, but our triangulator can't currently handle two-separate loops of vertices
+//                if (cached != null)
+//                    return cached; // this was one edge, (i.nextL), the raised copy will also be one edge
+
+                Edge edge = new Edge ( cornerMap.teg(i), cornerMap.teg(i.nextC) );
+
                 lowToHighEdge.put(i.nextL, edge);
-                edge.setAngle(i.nextL.getAngle());
-                edge.machine = i.nextL.machine;
+
+                edge.setAngle( i.nextL.getAngle() );
+                edge.machine = i.nextL.machine; // nextL is null when we have a non root global
+
                 return edge;
             }
-        };
-        
+         };
+
         LoopL<Corner> out = new LoopL<>();
-        Set<Corner> workingSet = new HashSet<>(liveCorners);
-        while (!workingSet.isEmpty()) {
+
+        Set<Corner> workingSet = new LinkedHashSet<> ( liveCorners );
+        while (!workingSet.isEmpty())
+        {
             Loop<Corner> loop = new Loop<>();
-            out.add(loop);
+            out.add( loop );
             Corner current = workingSet.iterator().next();
-            do {
-                Corner s = cornerMap.teg(current), e = cornerMap.teg(current.nextC);
-                segmentMap.addForwards(current, s);
-                Edge edge = edgeCache.get(current);
-                loop.append(s);
+            do
+            {
+                Corner s = cornerMap.teg( current ),
+                       e  = cornerMap.teg( current.nextC );
+
+                // one edge may have two segments, but the topology will not change between old and new,
+                // so we may store the leading corner to match segments
+                segmentMap.addForwards( current, s );
+
+                Edge edge = edgeCache.get( current );
+
+                loop.append( s );
                 s.nextC = e;
                 e.prevC = s;
                 s.nextL = edge;
                 e.prevL = edge;
-                workingSet.remove(current);
+
+                workingSet.remove( current );
                 current = current.nextC;
-            } while (workingSet.contains(current));
+            }
+            while (workingSet.contains( current ));
         }
+        
         return out;
     }
-    
-    public Cache<Corner, Collection<Corner>> getSegmentOriginator() {
+
+    public Cache<Corner, Collection<Corner>> getSegmentOriginator()
+    {
         return output.getSegmentOriginator();
     }
-    
-    public void parent(Face child, Face parent) {
+
+    // when a face is parented, it is flagged here. this allows overriding classes to get even process this information
+    public void parent( Face child, Face parent ) // parent is below (older than) child...
+    {
+        //override me
     }
-    
-    public static class SEC {
+
+    public static class SEC
+    {
         Corner start, end;
         Edge nextL, edge, prevL;
-        public SEC(Corner start, Edge edge) {
+
+        public SEC(Corner start, Edge edge)
+        {
             this.start = start;
             end = start.nextC;
             prevL = start.prevL;
             nextL = end.nextL;
+
             this.edge = edge;
         }
     }
     
+    
     public interface HeresTheArea {
-        public void heresTheArea(double area);
+    	public void heresTheArea(double area);
+    }
+
+    public void capAt (double cap) {
+    	capAt (cap, null);
+    	
+    }
+    public void capAt (double cap, HeresTheArea hta) {
+    	
+    	  qu.add(new HeightEvent() {
+
+    		  public double getHeight() {
+                  return cap;
+              }
+
+              public boolean process(Skeleton skel) {
+            	  
+                  SkeletonCapUpdate capUpdate = new SkeletonCapUpdate(skel);
+
+                  
+                  LoopL<Corner> flatTop = capUpdate.getCap(cap);
+                  
+                  capUpdate.update(new LoopL<>(), new SetCorrespondence<Corner, Corner>(), new DHash<Corner, Corner>());
+                  
+                  LoopL<Point3d> togo =
+                          flatTop.new Map<Point3d>()
+                          {
+                              @Override
+                              public Point3d map( Loopable<Corner> input )
+                              {
+                                  return new Point3d( input.get().x, input.get().y, input.get().z );
+                              }
+                          }.run();
+                          skel.output.addNonSkeletonOutputFace( togo, new Vector3d( 0, 0, 1 ) );
+                          
+                          if (hta != null)
+                        	  hta.heresTheArea( Loopz.area3( togo ) );
+                          
+                  DebugDevice.dump("post cap dump", skel);
+
+                  skel.qu.clearFaceEvents();
+                  skel.qu.clearOtherEvents();
+                  
+                  return true;
+              }
+          });
     }
     
-    public void capAt(double cap) {
-        capAt(cap, null);
-    }
-    
-    public void capAt(double cap, HeresTheArea hta) {
-        qu.add(new HeightEvent() {
-            public double getHeight() {
-                return cap;
-            }
-            public boolean process(Skeleton skel) {
-                SkeletonCapUpdate capUpdate = new SkeletonCapUpdate(skel);
-                LoopL<Corner> flatTop = capUpdate.getCap(cap);
-                capUpdate.update(new LoopL<>(), new SetCorrespondence<Corner, Corner>(), new DHash<Corner, Corner>());
-                LoopL<Point3d> togo = flatTop.new Map<Point3d>() {
-                    @Override
-                    public Point3d map(Loopable<Corner> input) {
-                        return new Point3d(input.get().x, input.get().y, input.get().z);
-                    }
-                }.run();
-                skel.output.addNonSkeletonOutputFace(togo, new Vector3d(0, 0, 1));
-                if (hta != null)
-                    hta.heresTheArea(Loopz.area3(togo));
-                
-                DebugDevice.dump("post cap dump", skel);
-                skel.qu.clearFaceEvents();
-                skel.qu.clearOtherEvents();
-                return true;
-            }
-        });
-    }
-    
-    public void refindAllFaceEventsLater() {
+    public void refindAllFaceEventsLater()
+    {
         refindFaceEvents = true;
     }
-    
-    private void refindFaceEventsIfNeeded() {
+
+    private void refindFaceEventsIfNeeded()
+    {
+        // on demand
         if (!refindFaceEvents)
             return;
-        
-        HeightCollision context = new HeightCollision();
-        for (Corner lc : new CloneConfirmIterator<>(liveCorners))
-            qu.addCorner(lc, context, true);
-        context.processHoriz(this);
-        refindFaceEvents = false;
+
+        /**
+         * Very expensive part - refind all collisions (including those already processed)
+         * MachineEvents remain in their current state
+         *
+         * should really only be done for those edges that have changed
+         */
+
+        // context collects events that must be processed immediately following (eg horizontals...)
+         HeightCollision context = new HeightCollision();
+
+//        qu.clearFaceEvents();
+        for ( Corner lc : new CloneConfirmIterator<Corner>(liveCorners) )
+            qu.addCorner( lc, context, true );
+
+        // if we are not adding new events (and this isn't adding the input the first time)
+        // this shouldn't do anything
+        context.processHoriz( this );
+		refindFaceEvents = false;
     }
-    
-    public void validate() {
-        if (false) {
-            // same debug routine as before…
+
+    /**
+     * Debug!
+     */
+    public void validate()
+    {
+        if (false)
+        {
+        Set <Corner> all = new LinkedHashSet<> ( liveCorners );
+        outer:
+        while (!all.isEmpty())
+        {
+            Corner start = all.iterator().next();
+            all.remove(start);
+
+            Corner next = start;
+
+            int count = 0;
+
+            do
+            {
+                count ++;
+                Corner c = next.nextC;
+                all.remove( c );
+
+                Edge e = next.nextL;
+                try
+                {
+                    assert ( c.nextC.prevC == c );
+                    assert ( c.prevC.nextC == c );
+
+                    assert (c.prevL == e);
+                    assert (c.prevC.nextL == e);
+
+//                    assert ( e.start.nextC == e.end );
+//                    assert ( e.end.prevC == e.start ); liveEdges.contains(e)
+                    for (Corner d : liveCorners)
+                    {
+                        if (d.nextL == e || d.prevL == e)
+                            assert ( e.currentCorners.contains( d ) );
+                        else
+                            assert ( !e.currentCorners.contains( d ) );
+                    }
+
+                    for ( Corner d : e.currentCorners )
+                        assert ( liveCorners.contains( d ) );
+
+                    assert (count < 100);
+                }
+                catch ( AssertionError f )
+                {
+                    System.err.println( " on edge is "+e);
+                    System.err.println( " validate error on corner " + c + "  on line " + f.getStackTrace()[0].getLineNumber() );
+                    f.printStackTrace();
+                }
+                finally
+                {
+                    if (count > 100)
+                        continue outer;
+                }
+
+                next = c;
+            }
+            while (next != start);
+        }
         }
     }
-    
-    public void setPlanTags(Edge edge, Set<Tag> features) {
-        planFeatures.put(edge, features);
+
+    public void setPlanTags (Edge edge, Set<Tag> features)
+    {
+        planFeatures.put( edge, features );
     }
-    
-    public Set<Tag> getPlanTags(Edge originator) {
-        return planFeatures.get(originator);
+
+    public Set<Tag> getPlanTags( Edge originator )
+    {
+        return planFeatures.get( originator );
     }
-    
-    public Comparator<Edge> getHorizontalComparator() {
-        return (o1, o2) -> {
-            if (volumeMaximising)
-                return Double.compare(o1.getAngle(), o2.getAngle());
-            else
-                return Double.compare(o2.getAngle(), o1.getAngle());
+
+    public Comparator<Edge> getHorizontalComparator()
+    {
+        return new Comparator<Edge>()
+        {
+            /**
+             * Volume maximizing resolution
+             */
+            public int compare( Edge o1, Edge o2 )
+            {
+                if ( volumeMaximising )
+                    return Double.compare( o1.getAngle(), o2.getAngle() );
+                else
+                    return Double.compare( o2.getAngle(), o1.getAngle() );
+            }
         };
     }
-    
-    public LoopL<Corner> findLoopLive() {
-        LoopL<Corner> out = new LoopL<>();
+
+    public LoopL<Corner> findLoopLive()
+    {
+        LoopL<Corner> out = new LoopL<Corner>();
         Set<Corner> togo = new HashSet<>(liveCorners);
-        while (!togo.isEmpty()) {
+
+        while (!togo.isEmpty())
+        {
             Loop<Corner> loop = new Loop<>();
             out.add(loop);
+
             Corner start = togo.iterator().next();
+
             Corner current = start;
             int handbrake = 0;
-            do {
+            do
+            {
                 togo.remove(current);
                 loop.append(current);
+
                 current = current.nextC;
-                handbrake++;
-            } while (current != start && handbrake < 1000);
-            
-            if (handbrake >= 1000) {
+            }
+            while (current !=start && handbrake++ < 1000);
+
+            if (handbrake >= 1000)
+            {
                 System.err.println("broken loops in findLiveLoop");
                 Thread.dumpStack();
             }
         }
-        return out;
+
+        return out; //out.count();
+
     }
-}
-       
+}        

--- a/src/org/twak/camp/Skeleton.java
+++ b/src/org/twak/camp/Skeleton.java
@@ -34,7 +34,7 @@ public class Skeleton {
 	
     public boolean preserveParallel = false;
     public boolean volumeMaximising = true;
-    public Set<Corner> liveCorners = new HashSet<>();  // order not essential in production
+    public Set<Corner> liveCorners = new HashSet<>();
     public Set<Edge> liveEdges = new HashSet<>();
     public CollisionQ qu;
     public double height = 0;
@@ -66,13 +66,13 @@ public class Skeleton {
         setup(corners);
     }
     
-    double cellSize = Double.MAX_VALUE;
+    private int edgeNearestNeighbors = Integer.MAX_VALUE;
     
     /**
      * Deprecated – given a loop of edges convert to corners.
      */
-	public Skeleton(LoopL<Edge> input, double cellSize) {
-		this.cellSize = cellSize;
+	public Skeleton(LoopL<Edge> input, int edgeNearestNeighbors) {
+		this.edgeNearestNeighbors = edgeNearestNeighbors;
 		setupForEdges(input);
 	}
 
@@ -85,10 +85,10 @@ public class Skeleton {
 		capAt(cap);
     }
     
-//    public Skeleton(LoopL<Edge> input, final double cap) {
-//        setupForEdges(input);
-//        capAt(cap);
-//    }
+    public Skeleton(LoopL<Edge> input, final double cap) {
+        setupForEdges(input);
+        capAt(cap);
+    }
     
     /**
      * Converts loops of edges (BAD!) to loops of corners (GOOD!)
@@ -154,7 +154,7 @@ public class Skeleton {
             c.prevL.currentCorners.add(c);
         }
         
-        qu = new CollisionQ(this, cellSize);
+        qu = new CollisionQ(this, edgeNearestNeighbors);
         
         // Add edges to their machines (accelerated structure)
         for (Edge e : allEdges.keySet()) {
@@ -266,7 +266,6 @@ public class Skeleton {
     }
     
     public void parent(Face child, Face parent) {
-        // override me if needed
     }
     
     public static class SEC {


### PR DESCRIPTION
You may want this to live on a separate branch.

Huge performance improvements, from:

1) Slightly faster Edge `collide()` and `isParallel()`.
2) Use a KD-Tree within the previously N^2 loop within `HeightCollision.process()` to quickly find collisions occurring at the same location.
3) And the biggest improvement: Users can now opt to use a constructor that has a `edgeNearestNeighbors` argument. When used, rather than colliding every single corner against every live edge, each corner is **collided only against its k-nearest edges** (queries are backed by an R-Tree). For concave shapes especially, you can get away with a very low k and reduce total time 100-fold.

The example below has 2400 vertices. With changes 1+2 we go from ~8.5s to ~5.0s. With change 3 (with k=8, which is the min number of nearest neighbour edges needed to produce a valid straight skeleton with this shape) we get to ~40ms!

![image](https://github.com/user-attachments/assets/6a364489-fd1e-4dfe-a5d2-82ebcb53594a)
